### PR TITLE
set properties as virtual

### DIFF
--- a/src/T4Config/Configurations.tt
+++ b/src/T4Config/Configurations.tt
@@ -34,7 +34,7 @@ namespace T4Config
 	public class Configurations : IConfigurations
 	{
 		<#  foreach(KeyValueConfigurationElement setting in settings) { #>
-		public string <#= setting.Key #> 
+		public virtual string <#= setting.Key #> 
 		{
 			get 
 			{
@@ -55,7 +55,7 @@ namespace T4Config
 	public class ConnectionStrings : IConnectionStrings
 	{
 		<#  foreach(ConnectionStringSettings setting in configuration.ConnectionStrings.ConnectionStrings) { #>
-		public string <#= setting.Name #> 
+		public virtual string <#= setting.Name #> 
 		{
 			get 
 			{


### PR DESCRIPTION
Allows for easy overriding of defaults if complex workflow for detecting machine based settings are required
