### PR TITLE
set namespace for included classes to be the namespace of the assembly

### DIFF
--- a/src/T4Config/Configurations.tt
+++ b/src/T4Config/Configurations.tt
@@ -9,6 +9,7 @@
 <#@ import namespace="System.Text.RegularExpressions" #>
 
 <#   
+	var namespaceName = System.Runtime.Remoting.Messaging.CallContext.LogicalGetData("NamespaceHint");
 	var configFile = (File.Exists("app.config")) ? "app.config" : "web.config";
 
 	var configurationFileMap = new ExeConfigurationFileMap();
@@ -22,7 +23,7 @@
 	var connectionStrings = configuration.ConnectionStrings.ConnectionStrings.Count;
 #>
 
-namespace T4Config
+namespace <#= namespaceName #>
 {
 	public interface IConfigurations
 	{


### PR DESCRIPTION
The method to obtain the namespace exists in VS 2010, but I've only tested this in 2013.
